### PR TITLE
小飞龙：创建es索引时指定字段time的类型为long，从而避免默认为text类型而导致排序报错。

### DIFF
--- a/plumelog-server/src/main/java/com/plumelog/server/client/ElasticLowerClient.java
+++ b/plumelog-server/src/main/java/com/plumelog/server/client/ElasticLowerClient.java
@@ -253,7 +253,8 @@ public class ElasticLowerClient extends AbstractServerClient {
             String properties = "\"properties\":{\"appName\":{\"type\":\"keyword\"}," +
                     "\"env\":{\"type\":\"keyword\"}," +
                     "\"appNameWithEnv\":{\"type\":\"keyword\"}," +
-                    "\"traceId\":{\"type\":\"keyword\"}" +
+                    "\"traceId\":{\"type\":\"keyword\"}," +
+					"\"time\":{\"type\":\"long\"}" +
                     "}";
             String ent = "{\"settings\":{\"number_of_shards\":" + InitConfig.ES_INDEX_SHARDS + ",\"number_of_replicas\":" + InitConfig.ES_INDEX_REPLICAS + ",\"refresh_interval\":\"" + InitConfig.ES_REFRESH_INTERVAL + "\"}";
             if (StringUtils.isEmpty(type)) {


### PR DESCRIPTION
创建es索引时指定字段time的类型为long，从而避免默认为text类型而导致排序报错。